### PR TITLE
Add static binary building

### DIFF
--- a/.github/workflows/go-lint-test-build-release.yaml
+++ b/.github/workflows/go-lint-test-build-release.yaml
@@ -108,7 +108,7 @@ jobs:
 
     - name: Build
       run: |
-        go build -o "$BINARY_NAME" -v
+        CGO_ENABLED=0 go build -o "$BINARY_NAME" -v
 
     - name: Upload Release Asset
       env:


### PR DESCRIPTION
Please make the go build static so we can use it within SUSE Harvester's web kubectl shell environment.